### PR TITLE
close #8: Add multipart upload to s3 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.egg-info/
 *.coverage
 *__pycache__/
+*.vscode
 nosetests.xml
 dist/


### PR DESCRIPTION
Modified put_df method to store pandas.Dataframe in S3 bucket:
	- in several files corresponding to parts parameter;
	- in sorted order based on sorted key columns.

Added tests:
	- test_put_df_success_dataframe_to_multiple_csv;
	- test_put_df_success_dataframe_with_sort_keys_to_multiple_csv.